### PR TITLE
feat: v2 디자인 토큰 이식 (M1-1)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,25 +1,87 @@
 @import "tailwindcss";
 
 @theme {
+  /* fonts */
   --font-serif: var(--font-fraunces), "Noto Serif KR", "Georgia", serif;
   --font-sans: var(--font-syne), "Noto Sans KR", sans-serif;
+  --font-body: "Inter", "Noto Sans KR", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: var(--font-jetbrains), "JetBrains Mono", "Fira Code", monospace;
 
+  /* color · base */
   --color-bg: #07070A;
   --color-surface: #0E0E14;
   --color-surface-2: #141419;
+  --color-surface-3: #1B1B22;
   --color-border: #1C1C28;
   --color-border-2: #28283A;
+  --color-border-3: #3A3A50;
 
+  /* color · text */
+  --color-text: #EDEDEF;
+  --color-text-2: #8A8A9A;
+  --color-text-3: #484858;
+
+  /* color · accents */
   --color-accent: #C8FF00;
+  --color-accent-ink: #07070A;
+  --color-accent-soft: rgba(200, 255, 0, 0.14);
+  --color-accent-line: rgba(200, 255, 0, 0.32);
+
+  /* color · palette */
   --color-red: #FF4060;
   --color-blue: #4D9EFF;
   --color-purple: #A78BFA;
   --color-orange: #FF8C42;
+  --color-green: #4ADE80;
 
-  --color-text: #EDEDEF;
-  --color-text-2: #8A8A9A;
-  --color-text-3: #484858;
+  /* category semantic colors */
+  --cat-news: var(--color-blue);
+  --cat-dev: var(--color-accent);
+  --cat-retrospective: var(--color-purple);
+  --cat-release: var(--color-orange);
+  --cat-etc: var(--color-text-2);
+}
+
+/* ── Non-theme design tokens (spacing, radius, shadow, layout, motion) ── */
+/* These are consumed via var(--*) only, not as Tailwind utilities. */
+:root {
+  /* spacing scale (4px base) */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+  --s-16: 64px;
+  --s-20: 80px;
+  --s-24: 96px;
+  --s-32: 128px;
+  --s-40: 160px;
+
+  /* radius */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 20px;
+  --r-full: 999px;
+
+  /* shadow */
+  --sh-1: 0 1px 0 rgba(255, 255, 255, 0.04) inset, 0 1px 2px rgba(0, 0, 0, 0.4);
+  --sh-2: 0 1px 0 rgba(255, 255, 255, 0.05) inset, 0 8px 24px rgba(0, 0, 0, 0.5);
+  --sh-glow: 0 0 0 1px var(--color-accent-line), 0 8px 40px rgba(200, 255, 0, 0.08);
+
+  /* layout */
+  --container: 1320px;
+  --container-narrow: 760px;
+  --container-prose: 720px;
+
+  /* motion */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 *,
@@ -48,7 +110,14 @@ body {
 
 ::selection {
   background-color: var(--color-accent);
-  color: #07070A;
+  color: var(--color-accent-ink);
+}
+
+/* keyboard focus ring — visible, lime accent */
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--r-xs);
 }
 
 ::-webkit-scrollbar {

--- a/src/components/CategoryBadge.tsx
+++ b/src/components/CategoryBadge.tsx
@@ -1,22 +1,14 @@
 import type { Category } from "@/types/post";
 import { CATEGORY_LABELS } from "@/lib/constants";
 
-const CATEGORY_COLORS: Record<Category, string> = {
-  news: "#4D9EFF",
-  dev: "#C8FF00",
-  retrospective: "#A78BFA",
-  release: "#FF4060",
-  etc: "#8A8A9A",
-};
-
 interface Props {
   category: Category;
   size?: "sm" | "md";
 }
 
 export function CategoryBadge({ category, size = "md" }: Props) {
-  const color = CATEGORY_COLORS[category];
   const label = CATEGORY_LABELS[category];
+  const cssVar = `var(--cat-${category})`;
 
   return (
     <span
@@ -24,9 +16,9 @@ export function CategoryBadge({ category, size = "md" }: Props) {
         size === "sm" ? "text-[10px] px-1.5 py-0.5" : "text-[11px] px-2 py-1"
       }`}
       style={{
-        color,
-        borderColor: `color-mix(in srgb, ${color} 30%, transparent)`,
-        backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+        color: cssVar,
+        borderColor: `color-mix(in srgb, ${cssVar} 30%, transparent)`,
+        backgroundColor: `color-mix(in srgb, ${cssVar} 8%, transparent)`,
       }}
     >
       {label}


### PR DESCRIPTION
## 요약
prototype `docs/redesign/v2-bundle/project/styles.css`의 다크 토큰 31종을 `src/app/globals.css`로 1:1 이식. M1 Foundations의 첫 PR.

## 변경 사항
- **`@theme`**: 색상·폰트 토큰 (`--color-surface-3`, `--color-border-3`, `--color-accent-{ink,soft,line}`, `--color-green`, `--cat-* 5종`, `--font-body`)
- **`:root`**: spacing(`--s-* 14종`)·radius(`--r-* 6종`)·shadow(`--sh-* 3종`)·container(3종)·ease(2종) — Tailwind 내장 유틸 충돌 회피용 분리
- **`CategoryBadge`**: 하드코딩 컬러 객체 제거, `var(--cat-*)` 참조로 교체 (release: red `#FF4060` → orange `#FF8C42`, prototype 기준)
- `:focus-visible` 룰 추가 (2px lime outline)
- `::selection` 컬러를 토큰(`--color-accent-ink`)으로 교체

## 분리된 작업
- 라이트 테마(prototype 707~768행) → **M4-1 (#20)**
- Inter 폰트 실로딩 → **M1-2 (#4)** (`--font-body` 토큰만 미리 추가됨)

## 검증
- [x] `pnpm build` 통과 (Next 16.2.6 Turbopack)
- [x] 토큰명이 prototype과 1:1 일치
- [x] `dev` 서버 기동 확인
- [ ] 브라우저 시각 회귀 (PM이 별도 확인)

## PM 결정 노트
#3 의 [comment](https://github.com/smc5720/smc5720.github.io/issues/3#issuecomment-4468880459) 참고.

Closes #3