### PR TITLE
feat: 폰트 로더 확장 — Inter body + Noto KR fallback (M1-2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,11 +1,11 @@
 @import "tailwindcss";
 
 @theme {
-  /* fonts */
-  --font-serif: var(--font-fraunces), "Noto Serif KR", "Georgia", serif;
-  --font-sans: var(--font-syne), "Noto Sans KR", sans-serif;
-  --font-body: "Inter", "Noto Sans KR", ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono: var(--font-jetbrains), "JetBrains Mono", "Fira Code", monospace;
+  /* fonts — all 4 role stacks reference next/font CSS variables */
+  --font-serif: var(--font-fraunces), var(--font-noto-serif-kr), Georgia, "Times New Roman", serif;
+  --font-sans: var(--font-syne), var(--font-noto-sans-kr), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-body: var(--font-inter), var(--font-noto-sans-kr), ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: var(--font-jetbrains), "JetBrains Mono", "Fira Code", ui-monospace, Menlo, monospace;
 
   /* color · base */
   --color-bg: #07070A;
@@ -102,7 +102,7 @@ html {
 body {
   background-color: var(--color-bg);
   color: var(--color-text);
-  font-family: var(--font-sans);
+  font-family: var(--font-body);
   min-height: 100vh;
   line-height: 1.6;
   word-break: keep-all;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,12 @@
 import type { Metadata } from "next";
-import { Fraunces, Syne, JetBrains_Mono } from "next/font/google";
+import {
+  Fraunces,
+  Syne,
+  JetBrains_Mono,
+  Inter,
+  Noto_Sans_KR,
+  Noto_Serif_KR,
+} from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
@@ -23,6 +30,29 @@ const jetbrains = JetBrains_Mono({
   variable: "--font-jetbrains",
   display: "swap",
   weight: ["400", "500", "600"],
+});
+
+// Inter is a variable font — no weight array needed
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+// Noto KR fonts: next/font downloads the full CSS (all unicode ranges including Korean)
+// at build time. The 'latin' subset here only controls the <link preload> hint, not coverage.
+const notoSansKR = Noto_Sans_KR({
+  subsets: ["latin"],
+  variable: "--font-noto-sans-kr",
+  display: "swap",
+  weight: ["400", "500", "700"],
+});
+
+const notoSerifKR = Noto_Serif_KR({
+  subsets: ["latin"],
+  variable: "--font-noto-serif-kr",
+  display: "swap",
+  weight: ["400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -52,7 +82,7 @@ export default function RootLayout({
   return (
     <html
       lang="ko"
-      className={`${fraunces.variable} ${syne.variable} ${jetbrains.variable}`}
+      className={`${fraunces.variable} ${syne.variable} ${jetbrains.variable} ${inter.variable} ${notoSansKR.variable} ${notoSerifKR.variable}`}
     >
       <body className="noise-overlay flex flex-col min-h-screen bg-bg">
         <Header />


### PR DESCRIPTION
## Summary
- next/font/google에 Inter(variable), Noto Sans KR, Noto Serif KR 합류
- `<html>`에 `--font-inter` / `--font-noto-sans-kr` / `--font-noto-serif-kr` 변수 추가
- `@theme` 4종 폰트 스택을 모두 `var(--font-*)`로 정합 — 리터럴 폰트명 제거
- `body` 기본 font-family를 `--font-sans`(Syne) → `--font-body`(Inter)로 분리, 헤더/라벨은 그대로 Syne

## Acceptance (이슈 #4)
- [x] Inter variable 추가
- [x] `<html>`에 4종(+Noto 2종) 변수 부여
- [x] `@theme --font-body` 가 next/font 변수 참조
- [x] Noto KR fallback이 self-host로 실제 전달 (latin subset은 preload hint만 제어, 한글 unicode-range는 next/font가 자동 호스팅)
- [x] \`pnpm build\` 통과

## Test plan
- [ ] 로컬에서 \`pnpm build\` 후 \`out/\`의 \`<head>\`에 Inter / Noto preload link 확인
- [ ] 브라우저에서 본문이 Inter, 헤더/라벨이 Syne, 한글 본문이 Noto Sans KR로 렌더되는지 시각 확인
- [ ] \`prefers-reduced-motion\` 무관 정상 표시

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)