### PR TITLE
feat: v2 prose/MDX 스타일 재작성 (M1-3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -215,43 +215,71 @@ a {
 
 /* ── MDX Prose ── */
 .prose {
-  color: color-mix(in srgb, var(--color-text) 90%, transparent);
-  line-height: 1.85;
-  font-family: var(--font-sans);
+  counter-reset: h2;
+  font-family: var(--font-body);
+  font-size: 17.5px;
+  line-height: 1.75;
+  color: var(--color-text);
   word-break: keep-all;
 }
 
 .prose > * + * {
-  margin-top: 1.4em;
+  margin-top: 1.25em;
 }
 
-.prose h1,
-.prose h2,
-.prose h3,
-.prose h4 {
-  font-family: var(--font-serif);
-  color: var(--color-text);
-  font-weight: 700;
-  line-height: 1.25;
-  letter-spacing: -0.02em;
-}
-
-.prose h1 { font-size: 2.4em; margin-top: 0; }
 .prose h2 {
-  font-size: 1.6em;
-  margin-top: 2.5em;
-  padding-bottom: 0.4em;
-  border-bottom: 1px solid var(--color-border);
+  font-family: var(--font-serif);
+  font-size: clamp(28px, 2.6vw, 36px);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  font-weight: 380;
+  margin: 2.2em 0 0.7em;
+  color: var(--color-text);
+  position: relative;
+  padding-top: 24px;
+  border-top: 1px solid var(--color-border-2);
 }
-.prose h3 { font-size: 1.25em; margin-top: 2em; }
-.prose h4 { font-size: 1.05em; margin-top: 1.5em; }
 
+.prose h2::before {
+  content: counter(h2, decimal-leading-zero);
+  counter-increment: h2;
+  position: absolute;
+  top: 28px;
+  right: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  color: var(--color-text-3);
+}
+
+.prose h3 {
+  font-family: var(--font-sans);
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin: 2em 0 0.4em;
+  color: var(--color-text);
+}
+
+.prose h4 {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 1.5em 0 0.3em;
+  color: var(--color-text);
+}
+
+/* anchor links injected by rehype-autolink-headings */
 .prose h2 .anchor,
 .prose h3 .anchor {
   opacity: 0;
-  margin-left: 0.5em;
+  margin-left: 0.4em;
+  font-family: var(--font-mono);
+  font-size: 0.6em;
   color: var(--color-text-3);
   transition: opacity 0.2s;
+  text-decoration: none;
+  border-bottom: none;
 }
 
 .prose h2:hover .anchor,
@@ -260,19 +288,19 @@ a {
 }
 
 .prose p {
-  color: color-mix(in srgb, var(--color-text) 82%, transparent);
+  color: var(--color-text);
+  text-wrap: pretty;
 }
 
 .prose a {
-  color: var(--color-accent);
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
-  text-underline-offset: 3px;
-  transition: text-decoration-color 0.15s;
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-accent-line);
+  transition: border-color 0.2s, color 0.2s;
 }
 
 .prose a:hover {
-  text-decoration-color: var(--color-accent);
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
 }
 
 .prose strong {
@@ -281,32 +309,36 @@ a {
 }
 
 .prose em {
-  color: color-mix(in srgb, var(--color-text) 75%, transparent);
   font-style: italic;
+  color: var(--color-text);
 }
 
 .prose blockquote {
-  border-left: 3px solid var(--color-accent);
-  padding: 0.75em 1.25em;
-  margin: 2em 0;
-  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
-  border-radius: 0 6px 6px 0;
+  margin: 1.8em 0;
+  padding: 8px 0 8px 24px;
+  border-left: 2px solid var(--color-accent);
+  font-family: var(--font-serif);
+  font-size: 22px;
+  line-height: 1.45;
+  letter-spacing: -0.005em;
+  color: var(--color-text);
+  font-style: italic;
 }
 
 .prose blockquote p {
   margin: 0;
-  color: var(--color-text-2);
+  color: var(--color-text);
   font-style: italic;
 }
 
 .prose code {
   font-family: var(--font-mono);
-  font-size: 0.875em;
+  font-size: 0.86em;
   background: var(--color-surface-2);
-  color: var(--color-accent);
-  padding: 0.15em 0.45em;
-  border-radius: 4px;
   border: 1px solid var(--color-border);
+  padding: 1.5px 6px;
+  border-radius: 4px;
+  color: var(--color-accent);
 }
 
 .prose pre {
@@ -330,65 +362,82 @@ a {
 
 .prose ul,
 .prose ol {
-  padding-left: 1.5em;
+  padding-left: 1.6em;
+}
+
+.prose ul li::marker {
+  color: var(--color-accent);
+}
+
+.prose ol li::marker {
+  color: var(--color-text-3);
+  font-family: var(--font-mono);
+  font-size: 0.85em;
 }
 
 .prose li + li {
   margin-top: 0.35em;
 }
 
-.prose ul li {
-  list-style-type: none;
-  position: relative;
-}
-
-.prose ul li::before {
-  content: "▸";
-  position: absolute;
-  left: -1.2em;
-  color: var(--color-accent);
-  font-size: 0.8em;
-  top: 0.15em;
-}
-
 .prose hr {
   border: none;
-  border-top: 1px solid var(--color-border);
+  height: 1px;
+  background: var(--color-border-2);
   margin: 3em 0;
 }
 
 .prose img {
   max-width: 100%;
-  border-radius: 8px;
-  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  border: 1px solid var(--color-border-2);
+  margin: 1.6em 0;
 }
 
 .prose table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.9em;
+  font-size: 14.5px;
+  font-family: var(--font-body);
+}
+
+.prose th,
+.prose td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border-2);
 }
 
 .prose th {
-  background: var(--color-surface-2);
-  padding: 0.7em 1em;
-  text-align: left;
-  font-weight: 600;
-  font-size: 0.8em;
-  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-text-2);
-  border: 1px solid var(--color-border);
+  font-weight: 500;
+  border-bottom-color: var(--color-border-3);
 }
 
 .prose td {
-  padding: 0.6em 1em;
-  border: 1px solid var(--color-border);
   color: var(--color-text-2);
 }
 
 .prose tr:hover td {
   background: var(--color-surface);
+}
+
+@media (max-width: 600px) {
+  .prose {
+    font-size: 16px;
+  }
+
+  .prose blockquote {
+    font-size: 18px;
+    padding-left: 16px;
+  }
+
+  .prose h2 {
+    font-size: 26px;
+  }
 }
 
 /* ── Reading Progress Bar ── */


### PR DESCRIPTION
## Summary
- `.prose` 블록을 v2 'Studio Log' 사양으로 전면 교체 (`docs/redesign/v2-bundle/project/styles.css:313~396` 기준)
- h2마다 `01·02·03…` decimal-leading-zero 카운터 자동 부여 (mono 11px, 우측 상단)
- blockquote / table / inline code / list / hr / img 모두 v2 토큰값으로 정합
- 본문 폰트 `--font-sans`(Syne) → `--font-body`(Inter), M1-2 분리 결과 반영
- `@media (max-width: 600px)` 모바일 폰트 다운스케일
- `.prose pre` 코드블록 컨테이너는 M1-4(#6) 범위로 미변경

## Test plan
- [x] `pnpm build` 통과 — 8개 정적 페이지 모두 생성
- [ ] hello-world / unreal-engine-5-tips 본문 dev 렌더 확인 (h2 카운터·blockquote·table·inline code·list)
- [ ] 모바일 뷰포트(≤600px)에서 폰트 다운 확인
- [ ] 키보드 포커스 링 정상

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)