### PR TITLE
feat: v2 Shiki 코드블록 + 컨테이너 디자인 (M1-4)

### DIFF
--- a/content/posts/hello-world.mdx
+++ b/content/posts/hello-world.mdx
@@ -22,8 +22,7 @@ tags: ["nextjs", "blog", "react", "tailwind"]
 
 ## 코드 예시
 
-```typescript
-// src/lib/posts.ts
+```typescript filename="src/lib/posts.ts"
 export function getPostBySlug(slug: string): Post | null {
   const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
   if (!fs.existsSync(filePath)) return null;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -341,15 +341,10 @@ a {
   color: var(--color-accent);
 }
 
+/* .prose pre is now handled by the .codeblock container component.
+   Only reset margin so the codeblock div controls spacing. */
 .prose pre {
-  position: relative;
-  background: var(--color-surface) !important;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 1.25em 1.5em;
-  overflow-x: auto;
-  font-size: 0.875em;
-  line-height: 1.75;
+  margin: 0;
 }
 
 .prose pre code {
@@ -358,6 +353,112 @@ a {
   border: none;
   color: inherit;
   font-size: inherit;
+}
+
+/* ─── code block container ─── */
+.codeblock {
+  margin: 1.8em 0;
+  border: 1px solid var(--color-border-2);
+  border-radius: var(--r-sm);
+  background: var(--color-surface);
+  overflow: hidden;
+}
+
+.codeblock-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px 8px 14px;
+  border-bottom: 1px solid var(--color-border-2);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+}
+
+.codeblock-head .filename {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-2);
+  letter-spacing: 0;
+}
+
+.codeblock-head .lang {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-3);
+}
+
+.codeblock-head-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.copy-btn {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-2);
+  border: 1px solid var(--color-border-2);
+  padding: 4px 8px;
+  border-radius: var(--r-xs);
+  background: transparent;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copy-btn {
+    transition: none;
+  }
+}
+
+.copy-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-3);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.copy-btn.ok {
+  color: var(--color-accent);
+  border-color: var(--color-accent-line);
+}
+
+.copy-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.codeblock pre {
+  margin: 0;
+  padding: 16px 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--color-text);
+  background: transparent !important;
+  border: none !important;
+}
+
+.codeblock pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+/* shiki renders .line spans; add subtle hover highlight */
+.codeblock .line {
+  display: block;
+  padding: 0 16px;
+}
+
+.codeblock .line:hover {
+  background: rgba(255, 255, 255, 0.018);
 }
 
 .prose ul,

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface CodeBlockProps {
+  children?: React.ReactNode;
+  "data-filename"?: string;
+  "data-language"?: string;
+  className?: string;
+  [key: string]: unknown;
+}
+
+export function CodeBlock({
+  children,
+  "data-filename": filename,
+  "data-language": dataLanguage,
+  className,
+  ...rest
+}: CodeBlockProps) {
+  const preRef = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Extract language from className (Shiki adds language-* via addLanguageClass)
+  const langFromClass = className
+    ?.split(" ")
+    .find((c) => c.startsWith("language-"))
+    ?.slice(9);
+  const lang = dataLanguage || langFromClass || "";
+
+  function handleCopy() {
+    const text = preRef.current?.innerText ?? "";
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    });
+  }
+
+  return (
+    <div className="codeblock">
+      <div className="codeblock-head">
+        <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+          <span style={{ display: "flex", gap: 4, alignItems: "center" }}>
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "var(--r-full)",
+                background: "var(--color-border-3)",
+                display: "block",
+                flexShrink: 0,
+              }}
+            />
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "var(--r-full)",
+                background: "var(--color-border-3)",
+                display: "block",
+                flexShrink: 0,
+              }}
+            />
+            <span
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "var(--r-full)",
+                background: "var(--color-accent)",
+                display: "block",
+                flexShrink: 0,
+              }}
+            />
+          </span>
+          <span className="filename">{filename || "untitled"}</span>
+        </div>
+        <div className="codeblock-head-actions">
+          {lang && <span className="lang">{lang}</span>}
+          <button
+            type="button"
+            className={copied ? "copy-btn ok" : "copy-btn"}
+            onClick={handleCopy}
+            aria-label={copied ? "Copied to clipboard" : "Copy code to clipboard"}
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      </div>
+      <pre ref={preRef} className={className} {...rest}>
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/MDXContent.tsx
+++ b/src/components/MDXContent.tsx
@@ -3,16 +3,23 @@ import rehypeSlug from "rehype-slug";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import remarkGfm from "remark-gfm";
 import rehypeShiki from "@shikijs/rehype";
+import { CodeBlock } from "./CodeBlock";
+import { parseMetaString, dataLanguageTransformer } from "@/lib/shiki-meta-transformer";
 
 interface Props {
   source: string;
 }
+
+const components = {
+  pre: CodeBlock,
+};
 
 export async function MDXContent({ source }: Props) {
   return (
     <div className="prose">
       <MDXRemote
         source={source}
+        components={components}
         options={{
           mdxOptions: {
             remarkPlugins: [remarkGfm],
@@ -29,8 +36,10 @@ export async function MDXContent({ source }: Props) {
               [
                 rehypeShiki,
                 {
-                  theme: "tokyo-night",
+                  theme: "vitesse-dark",
                   addLanguageClass: true,
+                  parseMetaString,
+                  transformers: [dataLanguageTransformer],
                 },
               ],
             ],

--- a/src/lib/shiki-meta-transformer.ts
+++ b/src/lib/shiki-meta-transformer.ts
@@ -1,0 +1,32 @@
+/**
+ * parseMetaString for @shikijs/rehype.
+ * Extracts `filename="..."` from the raw code fence meta string and
+ * returns it so Shiki serialises it onto the <pre> element as a data attribute.
+ */
+export function parseMetaString(
+  metaString: string
+): Record<string, string> | undefined {
+  const result: Record<string, string> = {};
+
+  const filenameMatch = metaString.match(/filename="([^"]+)"/);
+  if (filenameMatch) {
+    result["data-filename"] = filenameMatch[1];
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Shiki transformer that copies the resolved language name onto the <pre>
+ * element as `data-language`, so the CodeBlock component can display it
+ * in the header chip without parsing className.
+ */
+export const dataLanguageTransformer = {
+  name: "rico-blog:data-language",
+  pre(
+    this: { options: { lang: string } },
+    node: { properties: Record<string, unknown> }
+  ) {
+    node.properties["data-language"] = this.options.lang;
+  },
+};


### PR DESCRIPTION
Closes #6.

## Summary
- `@shikijs/rehype` 테마를 **tokyo-night → vitesse-dark** 로 교체. 프로토타입 6색 팔레트와 시각적으로 일치.
- 코드펜스 메타에서 `filename="src/lib/posts.ts"` 형태로 파일명을 파싱하고, 언어 정보와 함께 `<pre>`에 `data-filename` / `data-language`로 lift (`src/lib/shiki-meta-transformer.ts`).
- 클라이언트 컴포넌트 `CodeBlock` 신설 — 헤드바(점 3개 + 파일명 + 언어 칩 + Copy 버튼), `navigator.clipboard` 복사, 1.4s `ok` 상태, `:focus-visible` 링, `prefers-reduced-motion` 가드.
- `MDXRemote` 의 `components.pre`로 `CodeBlock` 주입 — Shiki가 만든 토큰화된 자식은 그대로 두고 컨테이너만 감쌈.
- `globals.css` 에 `.codeblock` 컨테이너 + 헤드바 + Copy 버튼 + 토큰 셀렉터 이식. 기존 `.prose pre` 는 margin 리셋만 남김.
- `hello-world.mdx` 코드펜스에 `filename` 메타 추가 (시각 검증용).

줄번호(`.ln`)는 명세대로 **M4로 이관**.

## Test plan
- [x] `pnpm build` 통과 (Next.js 16.2.6, 정적 export 8 페이지)
- [x] `out/blog/hello-world/index.html` 산출물 검증 — `.codeblock`, `data-filename="src/lib/posts.ts"`, `class="shiki vitesse-dark"`, 토큰별 인라인 컬러(`#4D9375`, `#CB7676`, `#80A665`, `#5DA994`, `#666666` 등) 모두 정상
- [x] 헤드바 구조 — 점 3개(회·회·accent) + filename + lang 칩 + Copy 버튼
- [x] `:focus-visible` 링, `prefers-reduced-motion: reduce` 가드 CSS 확인
- [ ] dev 서버에서 Copy 버튼 인터랙션 직접 확인 (머지 전 본인 점검 권장)
- [ ] 모바일(≤600px) 가로 스크롤 깨짐 없는지 확인

## Refs
- 디자인 소스: `docs/redesign/v2-bundle/project/styles.css:397~462`, `blog-components.jsx` CodeBlock
- 백로그: `docs/redesign/v2-backlog.md` (M1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)