### PR TITLE
feat: v2 Home 카테고리 카운터 그리드 (M2-2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -696,3 +696,105 @@ a {
   transition: width 0.05s linear;
   box-shadow: 0 0 8px var(--color-accent);
 }
+
+/* ── Category counter grid (.cat-grid) ── */
+.cat-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  border-top: 1px solid var(--color-border-2);
+  border-bottom: 1px solid var(--color-border-2);
+}
+
+.cat-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 28px 24px;
+  background: transparent;
+  text-align: left;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  border-left: 1px solid var(--color-border-2);
+  transition: background 0.2s var(--ease-out);
+}
+
+/* first cell: no left border */
+.cat-cell:first-child {
+  border-left: none;
+}
+
+.cat-cell:hover {
+  background: color-mix(in srgb, var(--color-text) 4%, transparent);
+}
+
+/* cat-cell count — large serif number */
+.cat-cell-count {
+  font-family: var(--font-serif);
+  font-size: 44px;
+  line-height: 1;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+/* cat-cell dot — 8×8 colored circle */
+.cat-cell-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  flex-shrink: 0;
+  align-self: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cat-cell {
+    transition: none;
+  }
+}
+
+/* Tablet ≤1100px: 3 columns */
+@media (max-width: 1100px) {
+  .cat-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  /* rows 2+: top border to separate row break */
+  .cat-grid > a:nth-child(n+4) {
+    border-top: 1px solid var(--color-border-2);
+  }
+
+  /* leftmost cell in each 3-col row has no left border */
+  .cat-grid > a:nth-child(3n+1) {
+    border-left: none;
+  }
+}
+
+/* Mobile ≤600px: 2 columns */
+@media (max-width: 600px) {
+  .cat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* reset tablet overrides then re-apply for 2-col */
+  .cat-grid > a:nth-child(n+4) {
+    border-top: none;
+  }
+
+  .cat-grid > a:nth-child(3n+1) {
+    border-left: 1px solid var(--color-border-2);
+  }
+
+  /* leftmost cell in each 2-col row has no left border */
+  .cat-grid > a:nth-child(2n+1) {
+    border-left: none;
+  }
+
+  /* rows 2+: top border */
+  .cat-grid > a:nth-child(n+3) {
+    border-top: 1px solid var(--color-border-2);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import Link from "next/link";
 import { getAllPosts, CATEGORY_LABELS } from "@/lib/posts";
 import { PostCard } from "@/components/PostCard";
-import { CategoryBadge } from "@/components/CategoryBadge";
 import type { Category } from "@/types/post";
+
+// Canonical category order for the cat-grid (01~05)
+const CAT_ORDER: Category[] = ["news", "dev", "retrospective", "release", "etc"];
 
 export default function HomePage() {
   const posts = getAllPosts();
@@ -192,31 +194,43 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── Content ── */}
-      <div className="max-w-6xl mx-auto px-6 pb-32">
+      {/* ── Category counter grid ── */}
+      <section
+        aria-label="카테고리별 글 수"
+        style={{ maxWidth: "var(--container)", margin: "0 auto", paddingLeft: 32, paddingRight: 32 }}
+      >
+        <nav className="cat-grid">
+          {/* Total cell */}
+          <Link href="/blog" className="cat-cell">
+            <span className="mono-label" style={{ color: "var(--color-text-3)" }}>Total</span>
+            <span className="cat-cell-count">
+              {String(posts.length).padStart(2, "0")}
+            </span>
+            <span className="mono-label" style={{ color: "var(--color-text-3)" }}>essays · since 2022</span>
+          </Link>
 
-        {Object.keys(categoryCount).length > 0 && (
-          <section className="mb-20">
-            <div className="flex items-center gap-4 mb-8">
-              <span className="text-[10px] font-mono tracking-[0.2em] text-text-3 uppercase">카테고리</span>
-              <span className="flex-1 h-px bg-border" />
-            </div>
-            <div className="flex flex-wrap gap-3">
-              {(Object.entries(categoryCount) as [Category, number][]).map(([cat, count]) => (
-                <Link
-                  key={cat}
-                  href={`/blog?category=${cat}`}
-                  className="group flex items-center gap-2 bg-surface border border-border rounded-sm px-4 py-2.5 hover:border-border-2 transition-colors"
-                >
-                  <CategoryBadge category={cat} size="sm" />
-                  <span className="text-xs font-mono text-text-3 group-hover:text-text-2 transition-colors">
-                    {count}
-                  </span>
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
+          {/* Per-category cells */}
+          {CAT_ORDER.map((cat, i) => (
+            <Link key={cat} href={`/blog?category=${cat}`} className="cat-cell">
+              <span className="mono-label" style={{ color: "var(--color-text-3)" }}>
+                {String(i + 1).padStart(2, "0")} · {CATEGORY_LABELS[cat]}
+              </span>
+              <span className="cat-cell-count">
+                {String(categoryCount[cat] ?? 0).padStart(2, "0")}
+                <span
+                  className="cat-cell-dot"
+                  aria-hidden="true"
+                  style={{ background: `var(--cat-${cat})` }}
+                />
+              </span>
+              <span className="mono-label" style={{ color: "var(--color-text-3)" }}>view filter →</span>
+            </Link>
+          ))}
+        </nav>
+      </section>
+
+      {/* ── Content ── */}
+      <div className="max-w-6xl mx-auto px-6 pb-32" style={{ paddingTop: 64 }}>
 
         {featured && (
           <section className="mb-20">


### PR DESCRIPTION
## Summary
- Home의 `CategoryBadge` chip 가로 나열을 v2 디자인의 **`.cat-grid` 6셀 그리드**로 교체 (Total 1셀 + CAT_ORDER 순 5셀)
- 카운트는 44px Fraunces (`var(--font-serif)`, `padStart(2, "0")`), 카테고리 셀은 8px `--cat-*` 컬러 dot 동반
- 반응형: 데스크탑 6열 · 태블릿(≤1100) 3열 · 모바일(≤600) 2열, nth-child 기반 보더 토글
- 셀 클릭 → Total은 `/blog`, 카테고리는 `/blog?category=<cat>` (`<Link>`)
- 토큰만 사용 (hex/rgb 하드코딩 0건), `:focus-visible` 전역 룰 활용, `prefers-reduced-motion` 가드 포함

## Test plan
- [ ] `pnpm build` 통과 (로컬 확인됨)
- [ ] 데스크탑(>1100px)에서 6열 균등, Total | 01 뉴스 | 02 개발 | 03 회고 | 04 릴리스 | 05 기타 순서
- [ ] 태블릿(601~1100px)에서 3열 + 4번째 셀부터 상단 보더 확인
- [ ] 모바일(≤600px)에서 2열 + 3번째 셀부터 상단 보더 확인
- [ ] 키보드 Tab으로 각 셀 포커스 링 확인
- [ ] `prefers-reduced-motion` 활성화 시 hover transition 없음

Closes #8